### PR TITLE
Support ICMP check

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ end
 ```
 
 ## example
+
+### Listeing check
+
 ```ruby
 > f = FastRemoteCheck.new("127.0.0.1", 54321, "127.0.0.1", 6379, 3)
  => #<FastRemoteCheck:0x139d560>
@@ -67,6 +70,16 @@ end
 (mirb):8: sys failed. errno: 11 message: Resource temporarily unavailable mrbgem message: recvfrom failed (RuntimeError)
 > f.connectable?
 (mirb):9: sys failed. errno: 115 message: Operation now in progress mrbgem message: connect failed (RuntimeError)
+>
+```
+
+### ICMP check
+
+```ruby
+> FastRemoteCheck::ICMP.new("8.8.8.8", 3).ping?
+ => true
+> FastRemoteCheck::ICMP.new("8.8.8.9", 3).ping?
+(mirb):4: sys failed. errno: 11 message: Resource temporarily unavailable mrbgem message: recv failed (RuntimeError)
 >
 ```
 

--- a/test/mrb_fastremotecheck.rb
+++ b/test/mrb_fastremotecheck.rb
@@ -49,3 +49,20 @@ assert("FastRemoteCheck#oepn_raw? for ip unreachable") do
   after = Time.now
   assert_true (after - before) < (timeout + 1)
 end
+
+assert("FastRemoteCheck::ICMP#ping? for ip reachable") do
+  # check redis port
+  t = FastRemoteCheck::ICMP.new "8.8.8.8", 3
+  assert_true t.ping?
+end
+
+assert("FastRemoteCheck::ICMP#ping? for ip unreachable") do
+  # check redis port
+  timeout = 2
+  t = FastRemoteCheck::ICMP.new "1.1.1.1", timeout
+  before = Time.now
+  assert_raise(RuntimeError) { t.ping? }
+  after = Time.now
+  assert_true (after - before) < (timeout + 1)
+end
+


### PR DESCRIPTION
```
> FastRemoteCheck::ICMP.new("8.8.8.8", 3).ping?
 => true
> FastRemoteCheck::ICMP.new("8.8.8.9", 3).ping?
(mirb):4: sys failed. errno: 11 message: Resource temporarily unavailable mrbgem message: recv failed (RuntimeError)
> 
```