### PR TITLE
Support timeout as float

### DIFF
--- a/src/mrb_fastremotecheck.c
+++ b/src/mrb_fastremotecheck.c
@@ -34,6 +34,7 @@
 #define PACKET_NOT_FOUND 0
 #define SYN_ACK_PACKET_FOUND 1
 #define RST_PACKET_FOUND 2
+#define FLOAT_TO_TIMEVAL(f, t) { t.tv_sec = f; t.tv_usec = (f - (double)t.tv_sec) * 1000000; }
 
 struct pseudo_ip_header {
   unsigned int src_ip;
@@ -147,7 +148,7 @@ static mrb_value mrb_fastremotecheck_init(mrb_state *mrb, mrb_value self)
   char *dst_ip;
   mrb_int src_port;
   mrb_int dst_port;
-  mrb_int timeout_arg = 0;
+  mrb_float timeout_arg = 0;
   struct tcphdr *tcphdr;
   struct pseudo_header *pheader;
   struct sockaddr_in *peer;
@@ -163,13 +164,11 @@ static mrb_value mrb_fastremotecheck_init(mrb_state *mrb, mrb_value self)
   DATA_TYPE(self) = &mrb_fastremotecheck_data_type;
   DATA_PTR(self) = NULL;
 
-  mrb_get_args(mrb, "zizii", &src_ip, &src_port, &dst_ip, &dst_port, &timeout_arg);
+  mrb_get_args(mrb, "zizif", &src_ip, &src_port, &dst_ip, &dst_port, &timeout_arg);
   data = (mrb_fastremotecheck_data *)mrb_malloc(mrb, sizeof(mrb_fastremotecheck_data));
 
   if (timeout_arg) {
-    /* for now, support sec only */
-    timeout.tv_sec = timeout_arg;
-    timeout.tv_usec = 0;
+    FLOAT_TO_TIMEVAL(timeout_arg, timeout);
   }
 
   tcphdr = (struct tcphdr *)mrb_malloc(mrb, sizeof(struct tcphdr));
@@ -357,7 +356,7 @@ static mrb_value mrb_icmp_init(mrb_state *mrb, mrb_value self)
 {
   mrb_icmp_data *data;
   char *dst_ip;
-  mrb_int timeout_arg = 0;
+  mrb_float timeout_arg = 0;
   struct sockaddr_in *addr;
   struct timeval timeout;
   timeout.tv_sec = 3; /* default timeout */
@@ -371,13 +370,12 @@ static mrb_value mrb_icmp_init(mrb_state *mrb, mrb_value self)
   DATA_TYPE(self) = &mrb_icmp_data_type;
   DATA_PTR(self) = NULL;
 
-  mrb_get_args(mrb, "zi", &dst_ip, &timeout_arg);
+  mrb_get_args(mrb, "zf", &dst_ip, &timeout_arg);
   data = (mrb_icmp_data *)mrb_malloc(mrb, sizeof(mrb_icmp_data));
 
   if (timeout_arg) {
     /* for now, support sec only */
-    timeout.tv_sec = timeout_arg;
-    timeout.tv_usec = 0;
+    FLOAT_TO_TIMEVAL(timeout_arg, timeout);
   }
 
   addr = (struct sockaddr_in *)mrb_malloc(mrb, sizeof(struct sockaddr_in));

--- a/test/mrb_fastremotecheck.rb
+++ b/test/mrb_fastremotecheck.rb
@@ -50,6 +50,16 @@ assert("FastRemoteCheck#open_raw? for ip unreachable") do
   assert_true (after - before) < (timeout + 1)
 end
 
+assert("FastRemoteCheck#open_raw? for ip unreachable with timeout as msec") do
+  # check redis port
+  timeout = 2.358
+  t = FastRemoteCheck.new "127.0.0.1", 54321, "203.0.113.1", 6380, timeout
+  before = Time.now
+  assert_raise(RuntimeError) { t.connectable? }
+  after = Time.now
+  assert_true (after - before) < (timeout + 1)
+end
+
 assert("FastRemoteCheck::ICMP#ping? for ip reachable") do
   t = FastRemoteCheck::ICMP.new "8.8.8.8", 3
   assert_true t.ping?
@@ -57,6 +67,15 @@ end
 
 assert("FastRemoteCheck::ICMP#ping? for ip unreachable") do
   timeout = 2
+  t = FastRemoteCheck::ICMP.new "203.0.113.1", timeout
+  before = Time.now
+  assert_raise(RuntimeError) { t.ping? }
+  after = Time.now
+  assert_true (after - before) < (timeout + 1)
+end
+
+assert("FastRemoteCheck::ICMP#ping? for ip unreachable with timeout as msec") do
+  timeout = 2.358
   t = FastRemoteCheck::ICMP.new "203.0.113.1", timeout
   before = Time.now
   assert_raise(RuntimeError) { t.ping? }


### PR DESCRIPTION
fast-remote-check can just now use float for socket timeout.