### PR TITLE
Wait for packet ICMP_ECHOREPLAY

### DIFF
--- a/src/mrb_fastremotecheck.c
+++ b/src/mrb_fastremotecheck.c
@@ -28,6 +28,7 @@
 #include <netinet/ip_icmp.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <sys/time.h>
 
 #define SYS_FAIL_MESSAGE_LENGTH 2048
 #define DONE mrb_gc_arena_restore(mrb, 0);
@@ -35,6 +36,7 @@
 #define SYN_ACK_PACKET_FOUND 1
 #define RST_PACKET_FOUND 2
 #define FLOAT_TO_TIMEVAL(f, t) { t.tv_sec = f; t.tv_usec = (f - (double)t.tv_sec) * 1000000; }
+#define TIMEVAL_TO_USEC(tv) (tv.tv_sec * 1000000L + tv.tv_usec)
 
 struct pseudo_ip_header {
   unsigned int src_ip;
@@ -399,6 +401,8 @@ static mrb_value mrb_icmp_ping(mrb_state *mrb, mrb_value self)
   struct icmphdr icmphdr;
   struct iphdr *recv_iphdr;
   struct icmphdr *recv_icmphdr;
+  long timediff = 0;
+  struct timeval begin_time, current_time;
   char buf[1500] = {0};
   mrb_icmp_data *data = (mrb_icmp_data *)DATA_PTR(self);
 
@@ -412,18 +416,31 @@ static mrb_value mrb_icmp_ping(mrb_state *mrb, mrb_value self)
     mrb_fastremotecheck_sys_fail(mrb, errno, "sendto failed");
   }
 
-  ret = recv(sock, buf, sizeof(buf), 0);
-  if (ret < 0) {
-    close(sock);
-    mrb_fastremotecheck_sys_fail(mrb, errno, "recv failed");
-  }
+  gettimeofday(&begin_time, NULL);
 
-  recv_iphdr = (struct iphdr *)buf;
-  recv_icmphdr = (struct icmphdr *)(buf + (recv_iphdr->ihl << 2));
+  while (1) {
+    gettimeofday(&current_time, NULL);
+    timediff = TIMEVAL_TO_USEC(current_time) - TIMEVAL_TO_USEC(begin_time);
 
-  if (data->dst_ip == recv_iphdr->saddr && recv_icmphdr->type == ICMP_ECHOREPLY) {
-    close(sock);
-    return mrb_true_value();
+    if (timediff > TIMEVAL_TO_USEC(data->timeout)) {
+      close(sock);
+      mrb_fastremotecheck_sys_fail(mrb, errno, "recv timeout");
+    }
+
+    memset(&buf, 0, sizeof(buf));
+    ret = recv(sock, buf, sizeof(buf), MSG_DONTWAIT);
+    if (ret < 0) {
+       continue;
+    } else {
+      recv_iphdr = (struct iphdr *)buf;
+      recv_icmphdr = (struct icmphdr *)(buf + (recv_iphdr->ihl << 2));
+
+      if (data->dst_ip == recv_iphdr->saddr && recv_icmphdr->type == ICMP_ECHOREPLY) {
+        close(sock);
+        return mrb_true_value();
+      }
+      continue;
+    }
   }
 
   close(sock);


### PR DESCRIPTION
Hi.

It working with multi-worker ngx_mruby.
I failed to process a large number of requests.

Sometimes, false is returned by: https://github.com/matsumotory/mruby-fast-remote-check/blob/master/src/mrb_fastremotecheck.c#L430

I think that packet is the [check processing](https://github.com/matsumotory/mruby-fast-remote-check/blob/master/src/mrb_fastremotecheck.c#L424) in a state that has not been reached.

Because I modified to wait for packet arrival.

Not degrade:

```ruby
## for reachable IP address
# time mruby/bin/mruby -e 'puts FastRemoteCheck::ICMP.new("8.8.8.8", 8).ping?'
true

real	0m0.021s
user	0m0.009s
sys	0m0.012s

## for unreacheble IP address
# time mruby/bin/mruby -e 'puts FastRemoteCheck::ICMP.new("1.255.255.255", 8).ping?'
trace (most recent call last):
	[0] -e:1
-e:1: sys failed. errno: 11 message: Resource temporarily unavailable mrbgem message: recv timeout (RuntimeError)

real	0m8.004s
user	0m3.121s
sys	0m4.880s
```