### PR TITLE
Wait for ICMP_ECHOREPLY packet alive

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,6 +2,7 @@ MRuby::Gem::Specification.new('mruby-fast-remote-check') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
   spec.add_test_dependency 'mruby-time', :core => 'mruby-time'
+  spec.add_test_dependency 'mruby-thread'
 
   task :test do
     sh 'which setcap' # check setcap command

--- a/src/mrb_fastremotecheck.c
+++ b/src/mrb_fastremotecheck.c
@@ -28,6 +28,7 @@
 #include <netinet/ip_icmp.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <sys/epoll.h>
 
 #define SYS_FAIL_MESSAGE_LENGTH 2048
 #define DONE mrb_gc_arena_restore(mrb, 0);
@@ -35,6 +36,7 @@
 #define SYN_ACK_PACKET_FOUND 1
 #define RST_PACKET_FOUND 2
 #define FLOAT_TO_TIMEVAL(f, t) { t.tv_sec = f; t.tv_usec = (f - (double)t.tv_sec) * 1000000; }
+#define TIMEVAL_TO_MSEC(tv) (tv.tv_sec * 1000 + tv.tv_usec)
 
 struct pseudo_ip_header {
   unsigned int src_ip;
@@ -400,6 +402,9 @@ static mrb_value mrb_icmp_ping(mrb_state *mrb, mrb_value self)
   struct iphdr *recv_iphdr;
   struct icmphdr *recv_icmphdr;
   char buf[1500] = {0};
+  int epfd, ready;
+  struct epoll_event event, events[1];
+
   mrb_icmp_data *data = (mrb_icmp_data *)DATA_PTR(self);
 
   sock = socket_with_timeout(mrb, SOCK_RAW, IPPROTO_ICMP, data->timeout);
@@ -412,22 +417,57 @@ static mrb_value mrb_icmp_ping(mrb_state *mrb, mrb_value self)
     mrb_fastremotecheck_sys_fail(mrb, errno, "sendto failed");
   }
 
-  ret = recv(sock, buf, sizeof(buf), 0);
-  if (ret < 0) {
+  epfd = epoll_create(1);
+  if(epfd == -1) {
+    close(epfd);
     close(sock);
-    mrb_fastremotecheck_sys_fail(mrb, errno, "recv failed");
+    mrb_fastremotecheck_sys_fail(mrb, errno, "epoll_create failed");
   }
 
-  recv_iphdr = (struct iphdr *)buf;
-  recv_icmphdr = (struct icmphdr *)(buf + (recv_iphdr->ihl << 2));
+  event.data.fd = sock;
+  event.events = EPOLLIN;
 
-  if (data->dst_ip == recv_iphdr->saddr && recv_icmphdr->type == ICMP_ECHOREPLY) {
+  if (epoll_ctl(epfd, EPOLL_CTL_ADD, sock, &event) != 0) {
+    close(epfd);
     close(sock);
-    return mrb_true_value();
+    mrb_fastremotecheck_sys_fail(mrb, errno, "epoll_ctl failed");
   }
 
-  close(sock);
-  return mrb_false_value();
+  while (1) {
+    ready = epoll_wait(epfd, events, 1, TIMEVAL_TO_MSEC(data->timeout));
+    if (ready < 0) {
+      close(epfd);
+      close(sock);
+      mrb_fastremotecheck_sys_fail(mrb, errno, "epoll_wait failed");
+    }
+
+    if (ready == 0) {
+      close(epfd);
+      close(sock);
+      mrb_fastremotecheck_sys_fail(mrb, errno, "epoll_wait timeout");
+    }    
+
+    memset(&buf, 0, sizeof(buf));
+    ret = recv(sock, buf, sizeof(buf), MSG_DONTWAIT);
+    if (ret < 0) {
+      if (errno == EAGAIN) {
+        continue;
+      }
+      close(epfd);
+      close(sock);
+      mrb_fastremotecheck_sys_fail(mrb, errno, "recv failed");
+    } else {
+      recv_iphdr = (struct iphdr *)buf;
+      recv_icmphdr = (struct icmphdr *)(buf + (recv_iphdr->ihl << 2));
+
+      if (data->dst_ip == recv_iphdr->saddr && recv_icmphdr->type == ICMP_ECHOREPLY) {
+        close(epfd);
+        close(sock);
+        return mrb_true_value();
+      }
+      continue;
+    }
+  }
 }
 
 void mrb_mruby_fast_remote_check_gem_init(mrb_state *mrb)

--- a/src/mrb_fastremotecheck.c
+++ b/src/mrb_fastremotecheck.c
@@ -28,6 +28,7 @@
 #include <netinet/ip_icmp.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <sys/time.h>
 
 #define SYS_FAIL_MESSAGE_LENGTH 2048
 #define DONE mrb_gc_arena_restore(mrb, 0);
@@ -35,6 +36,7 @@
 #define SYN_ACK_PACKET_FOUND 1
 #define RST_PACKET_FOUND 2
 #define FLOAT_TO_TIMEVAL(f, t) { t.tv_sec = f; t.tv_usec = (f - (double)t.tv_sec) * 1000000; }
+#define TIMEVAL_TO_MSEC(tv) (tv.tv_sec * 1000 + tv.tv_usec / 1000)
 
 struct pseudo_ip_header {
   unsigned int src_ip;
@@ -400,9 +402,13 @@ static mrb_value mrb_icmp_ping(mrb_state *mrb, mrb_value self)
   struct iphdr *recv_iphdr;
   struct icmphdr *recv_icmphdr;
   char buf[1500] = {0};
+  int timediff = 0;
+  struct timeval begin_time, current_time;
   mrb_icmp_data *data = (mrb_icmp_data *)DATA_PTR(self);
 
   sock = socket_with_timeout(mrb, SOCK_RAW, IPPROTO_ICMP, data->timeout);
+
+  gettimeofday(&begin_time, NULL);
 
   setup_icmphdr(ICMP_ECHO, 0, 0, 0, &icmphdr);
 
@@ -412,22 +418,31 @@ static mrb_value mrb_icmp_ping(mrb_state *mrb, mrb_value self)
     mrb_fastremotecheck_sys_fail(mrb, errno, "sendto failed");
   }
 
-  ret = recv(sock, buf, sizeof(buf), 0);
-  if (ret < 0) {
-    close(sock);
-    mrb_fastremotecheck_sys_fail(mrb, errno, "recv failed");
+  while (1) {
+    memset(&buf, 0, sizeof(buf));
+    ret = recv(sock, buf, sizeof(buf), 0);
+    if (ret < 0) {
+      close(sock);
+      mrb_fastremotecheck_sys_fail(mrb, errno, "recv failed");
+    } else {
+      recv_iphdr = (struct iphdr *)buf;
+      recv_icmphdr = (struct icmphdr *)(buf + (recv_iphdr->ihl << 2));
+
+      if (data->dst_ip == recv_iphdr->saddr && recv_icmphdr->type == ICMP_ECHOREPLY) {
+        close(sock);
+        return mrb_true_value();
+      }
+
+      gettimeofday(&current_time, NULL);
+      timediff = TIMEVAL_TO_MSEC(current_time) - TIMEVAL_TO_MSEC(begin_time);
+
+      if (timediff > TIMEVAL_TO_MSEC(data->timeout)) {
+        close(sock);
+        mrb_fastremotecheck_sys_fail(mrb, errno, "recv timeout");
+      }
+      continue;
+    }
   }
-
-  recv_iphdr = (struct iphdr *)buf;
-  recv_icmphdr = (struct icmphdr *)(buf + (recv_iphdr->ihl << 2));
-
-  if (data->dst_ip == recv_iphdr->saddr && recv_icmphdr->type == ICMP_ECHOREPLY) {
-    close(sock);
-    return mrb_true_value();
-  }
-
-  close(sock);
-  return mrb_false_value();
 }
 
 void mrb_mruby_fast_remote_check_gem_init(mrb_state *mrb)

--- a/test/mrb_fastremotecheck.rb
+++ b/test/mrb_fastremotecheck.rb
@@ -84,10 +84,8 @@ assert("FastRemoteCheck::ICMP#ping? for ip unreachable with timeout as msec") do
 end
 
 assert("FastRemoteCheck::ICMP#ping? for wait packet reply") do
-  t1 = Thread.new { FastRemoteCheck::ICMP.new("1.1.1.1", 1).ping? }
-  t2 = Thread.new { FastRemoteCheck::ICMP.new("203.0.113.1", 5).ping? rescue "raised" }
-  t3 = Thread.new { FastRemoteCheck::ICMP.new("8.8.8.8", 1).ping? }
-  assert_true(t1.join)
-  assert_equal("raised", t2.join)
-  assert_true(t3.join)
+  t1 = Thread.new { FastRemoteCheck::ICMP.new("203.0.113.1", 5).ping? rescue "raised" }
+  t2 = Thread.new { FastRemoteCheck::ICMP.new("127.0.0.1", 1).ping? }
+  assert_equal("raised", t1.join)
+  assert_true(t2.join)
 end

--- a/test/mrb_fastremotecheck.rb
+++ b/test/mrb_fastremotecheck.rb
@@ -82,3 +82,12 @@ assert("FastRemoteCheck::ICMP#ping? for ip unreachable with timeout as msec") do
   after = Time.now
   assert_true (after - before) < (timeout + 1)
 end
+
+assert("FastRemoteCheck::ICMP#ping? for wait packet reply") do
+  ret = []
+  th = []
+  th << Thread.new { FastRemoteCheck::ICMP.new("8.8.8.8", 3).ping? }
+  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.1", 3).ping? }
+  th.each {|t| ret << t.join}
+  assert_false(ret.include?(false))
+end

--- a/test/mrb_fastremotecheck.rb
+++ b/test/mrb_fastremotecheck.rb
@@ -84,8 +84,8 @@ assert("FastRemoteCheck::ICMP#ping? for ip unreachable with timeout as msec") do
 end
 
 assert("FastRemoteCheck::ICMP#ping? for wait packet reply") do
-  t1 = Thread.new { FastRemoteCheck::ICMP.new("203.0.113.1", 5).ping? rescue "raised" }
+  t1 = Thread.new { FastRemoteCheck::ICMP.new("203.0.113.1", 5).ping? }
   t2 = Thread.new { FastRemoteCheck::ICMP.new("127.0.0.1", 1).ping? }
-  assert_equal("raised", t1.join)
+  assert_true(t1.join.is_a?(RuntimeError))
   assert_true(t2.join)
 end

--- a/test/mrb_fastremotecheck.rb
+++ b/test/mrb_fastremotecheck.rb
@@ -84,13 +84,10 @@ assert("FastRemoteCheck::ICMP#ping? for ip unreachable with timeout as msec") do
 end
 
 assert("FastRemoteCheck::ICMP#ping? for wait packet reply") do
-  ret = []
-  th = []
-  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.1", 3).ping? }
-  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.2", 3).ping? }
-  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.3", 3).ping? }
-  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.4", 3).ping? }
-  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.5", 3).ping? }
-  th.each {|t| ret << t.join}
-  assert_false(ret.include?(false))
+  t1 = Thread.new { FastRemoteCheck::ICMP.new("1.1.1.1", 1).ping? }
+  t2 = Thread.new { FastRemoteCheck::ICMP.new("203.0.113.1", 5).ping? rescue "raised" }
+  t3 = Thread.new { FastRemoteCheck::ICMP.new("8.8.8.8", 1).ping? }
+  assert_true(t1.join)
+  assert_equal("raised", t2.join)
+  assert_true(t3.join)
 end

--- a/test/mrb_fastremotecheck.rb
+++ b/test/mrb_fastremotecheck.rb
@@ -86,8 +86,11 @@ end
 assert("FastRemoteCheck::ICMP#ping? for wait packet reply") do
   ret = []
   th = []
-  th << Thread.new { FastRemoteCheck::ICMP.new("8.8.8.8", 3).ping? }
   th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.1", 3).ping? }
+  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.2", 3).ping? }
+  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.3", 3).ping? }
+  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.4", 3).ping? }
+  th << Thread.new { FastRemoteCheck::ICMP.new("1.1.1.5", 3).ping? }
   th.each {|t| ret << t.join}
   assert_false(ret.include?(false))
 end


### PR DESCRIPTION
https://github.com/matsumotory/mruby-fast-remote-check/pull/7 のPRの修正版として、以下のように問題の特定と修正を行いました。

### 発生した問題

同時に単一のsocket上で複数のIPアドレスに ICMP Echo Reqest を送信した場合に最初の ICMP Echo Reply の到着によって、本来別のIPアドレスからの Reply を待つプロセスもrecv後、リトライすることなく `false` を返してしまう。

### 再現テスト手順と結果の説明

#### 再現手順

今回は分かりやすいように以下のようなコードを挿入してPrintデバッグを実施しました。
https://github.com/takumakume/mruby-fast-remote-check/commit/a146830368c0ad604e6208765af13e3d97e7e013

1. テストコード (test.rb)

  ```ruby
  ip = ARGV[0]
  puts " ==> #{ip} #{FastRemoteCheck::ICMP.new(ip, 3).ping?}"
  ```

2. tcpdumpによりICMPパケットの収集

  ```
  tcpdump -s0 -nn -w tcpdump_$(date +%Y%m%d%H%M%S).cap icmp
  ```

3. テストコードを並行で実行

  ```sh
  echo "8.8.8.8
  1.1.1.1" | xargs -P 2 -L 1 strace -Ttt -ff -s 1500000 -o strace_$(date +%Y%m%d%H%M%S) mruby/bin/mruby ~/test.rb
  ```

#### 結果

以下にtcpdumpの結果と、straceの結果を時系列に並べて説明する。

```sh
# ソケットを(4)で作成
15:31:18.865712 [8.8.8.8] socket(AF_INET, SOCK_RAW, IPPROTO_ICMP) = 4 <0.000033>
15:31:18.865771 [8.8.8.8] setsockopt(4, SOL_SOCKET, SO_RCVTIMEO, "\3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) = 0 <0.000009>
15:31:18.865802 [8.8.8.8] setsockopt(4, SOL_SOCKET, SO_SNDTIMEO, "\3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) = 0 <0.000008>
# 8.8.8.8へICMPを送付
15:31:18.865831 [8.8.8.8] sendto(4, "\10\0\367\377\0\0\0\0", 8, 0, {sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("8.8.8.8")}, 16) = 8 <0.000120>
# 8.8.8.8へのICMP echoが送信される
15:31:18.865912 [tcpdump] IP server > 8.8.8.8: ICMP echo request, id 0, seq 0, length 8
# recvを開始 (ブロッキング)
15:31:18.866035 [8.8.8.8] recvfrom(4, "E\0\0\34\342\244@\0?\1=\36\10\10\10\10\n\0\2\17\0\0\377\377\0\0\0\0", 1500, 0, NULL, NULL) = 28 <0.022840>

# 別プロセスでソケットを(4)で作成
15:31:18.868766 [1.1.1.1] socket(AF_INET, SOCK_RAW, IPPROTO_ICMP) = 4 <0.000035>
15:31:18.868824 [1.1.1.1] setsockopt(4, SOL_SOCKET, SO_RCVTIMEO, "\3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) = 0 <0.000009>
15:31:18.868855 [1.1.1.1] setsockopt(4, SOL_SOCKET, SO_SNDTIMEO, "\3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) = 0 <0.000008>
# 1.1.1.1へICMPを送付
15:31:18.868882 [1.1.1.1] sendto(4, "\10\0\367\377\0\0\0\0", 8, 0, {sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("1.1.1.1")}, 16) = 8 <0.000106>
# 1.1.1.1へのICMP echoが送信される
15:31:18.868916 [tcpdump] IP server > 1.1.1.1: ICMP echo request, id 0, seq 0, length 8
# recvを開始 (ブロッキング)
15:31:18.869023 [1.1.1.1] recvfrom(4, "E\0\0\34\342\244@\0?\1=\36\10\10\10\10\n\0\2\17\0\0\377\377\0\0\0\0", 1500, 0, NULL, NULL) = 28 <0.019892>

# 8.8.8.8からのICMP echo replyが到着
# ここで2つの recvfrom が受け取る
15:31:18.888700 [tcpdump] IP 8.8.8.8 > server: ICMP echo reply, id 0, seq 0, length 8

15:31:18.888953 [8.8.8.8] fstat(1, {st_mode=S_IFCHR|0620, st_rdev=makedev(136, 1), ...}) = 0 <0.000014>
15:31:18.889005 [1.1.1.1] fstat(1, {st_mode=S_IFCHR|0620, st_rdev=makedev(136, 1), ...}) = 0 <0.000189>
15:31:18.889065 [8.8.8.8] mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7fcc6e79c000 <0.000018>

# 8.8.8.8からのICMP echo replyが到着
# socketには入るが、recvはもう起きない
15:31:18.889147 [tcpdump] IP 1.1.1.1 > server: ICMP echo reply, id 0, seq 0, length 8
15:31:18.889194 [8.8.8.8] close(4)                = 0 <0.000023>

15:31:18.889249 [1.1.1.1] mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7fe205c47000 <0.000014>

# 8.8.8.8からのreplyをrecvしているので True
15:31:18.889270 [8.8.8.8] write(1, "data->dst_ip, recv_iphdr->saddr : 134744072, 134744072 ==> 8.8.8.8 true", 71) = 71 <0.000269>

15:31:18.889308 [1.1.1.1] close(4)                = 0 <0.000017>

# 8.8.8.8からのreplyをrecvしているので False
15:31:18.889367 [1.1.1.1] write(1, "data->dst_ip, recv_iphdr->saddr : 16843009, 134744072 ==> 1.1.1.1 false", 71) = 71 <0.000017>
```

### 本PRの解決手法

- これまで通りにrecv後に、ICMPパケットのチェック処理を行う。そこで、チェックが通らない場合は再度recv待機する。
- epollを使って、socketを監視してrecvをリトライする。タイムアウトもepollで行う。

### 同様のテスト手順の確認結果

`本PRの解決手法` で示した意図通りに動作している。

```sh
23:41:17.395409 [8.8.8.8] socket(AF_INET, SOCK_RAW, IPPROTO_ICMP) = 4 <0.000039>
23:41:17.395472 [8.8.8.8] setsockopt(4, SOL_SOCKET, SO_RCVTIMEO, "\3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) = 0 <0.000011>
23:41:17.395508 [8.8.8.8] setsockopt(4, SOL_SOCKET, SO_SNDTIMEO, "\3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) = 0 <0.000007>
23:41:17.395536 [8.8.8.8] sendto(4, "\10\0\367\377\0\0\0\0", 8, 0, {sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("8.8.8.8")}, 16) = 8 <0.000277>
23:41:17.395573 [tcpdump] IP server > 8.8.8.8: ICMP echo request, id 0, seq 0, length 8
23:41:17.395862 [8.8.8.8] epoll_create(1)         = 5 <0.000014>
23:41:17.395906 [8.8.8.8] epoll_ctl(5, EPOLL_CTL_ADD, 4, {EPOLLIN, {u32=4, u64=4642859646980}}) = 0 <0.000009>
23:41:17.395943 [8.8.8.8] epoll_wait(5, [{EPOLLIN, {u32=4, u64=4642859646980}}], 1, 3000) = 1 <0.035051>
23:41:17.396938 [1.1.1.1] socket(AF_INET, SOCK_RAW, IPPROTO_ICMP) = 4 <0.000040>
23:41:17.397017 [1.1.1.1] setsockopt(4, SOL_SOCKET, SO_RCVTIMEO, "\3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) = 0 <0.000009>
23:41:17.397045 [1.1.1.1] setsockopt(4, SOL_SOCKET, SO_SNDTIMEO, "\3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) = 0 <0.000007>
23:41:17.397070 [1.1.1.1] sendto(4, "\10\0\367\377\0\0\0\0", 8, 0, {sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("1.1.1.1")}, 16) = 8 <0.000154>
23:41:17.397106 [tcpdump] IP server > 1.1.1.1: ICMP echo request, id 0, seq 0, length 8
23:41:17.397268 [1.1.1.1] epoll_create(1)         = 5 <0.000013>
23:41:17.397308 [1.1.1.1] epoll_ctl(5, EPOLL_CTL_ADD, 4, {EPOLLIN, {u32=4, u64=9266893077904097284}}) = 0 <0.000008>
23:41:17.397338 [1.1.1.1] epoll_wait(5, [{EPOLLIN, {u32=4, u64=9266893077904097284}}], 1, 3000) = 1 <0.033591>
23:41:17.430764 [tcpdump] IP 8.8.8.8 > server: ICMP echo reply, id 0, seq 0, length 8
23:41:17.431053 [1.1.1.1] recvfrom(4, "E\0\0\34V~@\0?\1\311D\10\10\10\10\n\0\2\17\0\0\377\377\0\0\0\0", 1500, MSG_DONTWAIT, NULL, NULL) = 28 <0.000012>
23:41:17.431053 [8.8.8.8] recvfrom(4, "E\0\0\34V~@\0?\1\311D\10\10\10\10\n\0\2\17\0\0\377\377\0\0\0\0", 1500, MSG_DONTWAIT, NULL, NULL) = 28 <0.000012>
# ここで、別のIPアドレスからのリプライのため再度epollで待つ
23:41:17.431110 [1.1.1.1] epoll_wait(5, [{EPOLLIN, {u32=4, u64=9266893077904097284}}], 1, 3000) = 1 <0.013761>
23:41:17.431118 [8.8.8.8] close(5)                = 0 <0.000015>
23:41:17.431154 [8.8.8.8] close(4)                = 0 <0.000062>
23:41:17.431312 [8.8.8.8] fstat(1, {st_mode=S_IFCHR|0620, st_rdev=makedev(136, 2), ...}) = 0 <0.000009>
23:41:17.431356 [8.8.8.8] mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f05bec9a000 <0.000012>
23:41:17.431394 [8.8.8.8] write(1, " ==> 8.8.8.8 true", 17) = 17 <0.000226>
23:41:17.431764 [8.8.8.8] write(1, "\n", 1)       = 1 <0.000207>
23:41:17.432026 [8.8.8.8] close(3)                = 0 <0.000012>
23:41:17.432060 [8.8.8.8] munmap(0x7f05bec9b000, 4096) = 0 <0.000019>
23:41:17.432215 [8.8.8.8] exit_group(0)           = ?
23:41:17.432334 [8.8.8.8] +++ exited with 0 +++
23:41:17.444778 [tcpdump] IP 1.1.1.1 > server: ICMP echo reply, id 0, seq 0, length 8
23:41:17.444939 [1.1.1.1] recvfrom(4, "E\0\0\34V\201@\0?\1\327O\1\1\1\1\n\0\2\17\0\0\377\377\0\0\0\0", 1500, MSG_DONTWAIT, NULL, NULL) = 28 <0.000014>
23:41:17.445033 [1.1.1.1] close(5)                = 0 <0.000014>
23:41:17.445070 [1.1.1.1] close(4)                = 0 <0.000019>
23:41:17.445137 [1.1.1.1] fstat(1, {st_mode=S_IFCHR|0620, st_rdev=makedev(136, 2), ...}) = 0 <0.000010>
23:41:17.445177 [1.1.1.1] mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f7d830ed000 <0.000016>
23:41:17.445228 [1.1.1.1] write(1, " ==> 1.1.1.1 true", 17) = 17 <0.000032>
23:41:17.445300 [1.1.1.1] write(1, "\n", 1)       = 1 <0.000078>
23:41:17.445422 [1.1.1.1] close(3)                = 0 <0.000012>
23:41:17.445456 [1.1.1.1] munmap(0x7f7d830ee000, 4096) = 0 <0.000022>
23:41:17.445669 [1.1.1.1] exit_group(0)           = ?
23:41:17.445904 [1.1.1.1] +++ exited with 0 +++
```

なお、epollで待つ動作のためCPU専有はしない。

```sh
# time mruby/bin/mruby -e 'p FastRemoteCheck::ICMP.new("1.255.255.255", 3).ping?'
trace (most recent call last):
	[0] -e:1
-e:1: sys failed. errno: 0 message: Success mrbgem message: epoll_wait timeout (RuntimeError)

real	0m3.007s
user	0m0.002s
sys	0m0.002s
```

テストコードまで落とし込むことはできなかったが、テスト手順を明確に示し、再現可能な状態にした上で原因の特定をすることはできました。
